### PR TITLE
fix cb in case of errors in player.status()

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = function () {
             InstanceID: player.client.instanceId
           }
           player.client.callAction('AVTransport', 'GetPositionInfo', params, function (err, res) {
-            if (err) return
+            if (err) return acb()
             var position = parseTime(res.AbsTime) | parseTime(res.RelTime)
             acb(null, position)
           })
@@ -146,7 +146,7 @@ module.exports = function () {
         Channel: 'Master'
       }
       player.client.callAction('RenderingControl', 'GetVolume', params, function (err, res) {
-        if (err) return
+        if (err) return cb()
         var volume = res.CurrentVolume ? parseInt(res.CurrentVolume) : 0
         cb(null, volume)
       })


### PR DESCRIPTION
`player.status(cb)` builds its result based on two calls on the media renderer. In case one of these fail, `cb` is never called. I made this fix so that errors are silently ignored, and results from failed calls to the media renderer will just be missing from the result of `player.status()`. If you prefer to change it so that any of the two calls (GetPositionInfo, GetVolume) failing will cause `player.status()` to fail, let me know. Will update this accordingly.