### PR TITLE
pass correct error on play failure when seek is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,10 @@ module.exports = function () {
 
         var callback = cb
         if (opts.seek) {
-          callback = function () {
+          callback = function(err) {
+            if(err) {
+              return cb(err)
+            }
             player.seek(opts.seek, cb)
           }
         }


### PR DESCRIPTION
This issue only affects use cases where `opts.seek` is set in the call to `player.play(url, opts, cb)`. When `seek` is set, the `cb` provided to `player.play(...)` is replaced with one that follows-up on the `client.load(...)` with a `client.seek(...)` call, and then calls the original callback. In case `client.load(...)` fails, it currently ignores the error and calls `client.seek(...)` which then usually fails and the seek error is returned to the original callback. This change fixes that by skipping `client.seek(...)` in case `client.load(...)` fails, providing useful error details to users of this library.