### PR TITLE
fix socket/memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,21 @@ module.exports = function () {
 	}
   }
 
+  that.on('removeListener', function () {
+    if (ssdp && that.listenerCount('update') === 0) {
+      ssdp.stop()
+    }
+  })
+
   that.destroy = function () {
+    debug('destroying ssdp...')
+    if (ssdp) {
+      ssdp.stop()
+    }
+  }
+
+  that.close = function () {
+    that.removeAllListeners('update')
   }
 
   that.update()


### PR DESCRIPTION
When used in long-running applications, it may be desirable to recreate a dlnacasts2 instance. This is due to the fact that the module collects all found devices, but never prunes that list. When an old instance is no longer referenced, the UDP socket created by node-ssdp is not closed because `ssdp.stop()` is never called.

This PR provides 2 ways for users of dlnacasts2 to signal their desire to release all related resources:
1. By removing all `"update"` listeners. Each time an `"update"` listener is removed, the module checks how many listeners are remaining. Once that number hits 0, calls `ssdp.stop()`
2. By calling `close()`. E.g.:
```
const search = dlnacasts().on('update', ...);
// do stuff
search.close()
```